### PR TITLE
feat: add streaming/cancellable API

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,3 +1,3 @@
 module.exports = {
-  bundlesize: { maxSize: '12kB' }
+  bundlesize: { maxSize: '12.1kB' }
 }

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   "dependencies": {
     "buffer": "^5.5.0",
     "idb": "^5.0.2",
-    "interface-datastore": "^0.8.3"
+    "interface-datastore": "^1.0.2"
   },
   "devDependencies": {
-    "aegir": "^21.4.5",
+    "aegir": "^22.0.0",
     "chai": "^4.2.0",
-    "datastore-core": "^1.0.0",
-    "datastore-level": "^0.14.1",
+    "datastore-core": "^1.1.0",
+    "datastore-level": "^1.1.0",
     "dirty-chai": "^2.0.1",
     "ipfs-utils": "^2.2.0",
     "iso-random-stream": "^1.1.1"

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 const { Buffer } = require('buffer')
 const { openDB, deleteDB } = require('idb')
-const { Key, Errors, utils } = require('interface-datastore')
+const { Key, Errors, utils, Adapter } = require('interface-datastore')
 const { filter, sortAll } = utils
 
 const isStrictTypedArray = (arr) => {
@@ -70,8 +70,10 @@ const queryIt = async function * (q, store, location) {
   }
 }
 
-class IdbDatastore {
+class IdbDatastore extends Adapter {
   constructor (location, options = {}) {
+    super()
+
     this.store = null
     this.options = options
     this.location = options.prefix + location


### PR DESCRIPTION
Upgrades to the latest interface-datastore which includes streaming APIs and passing AbortControllers.

Uses the new Adapter class to implement these with minimal code changes.