### PR TITLE
fix: wrap operations in transactions

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,3 +1,3 @@
 module.exports = {
-  bundlesize: { maxSize: '13.7kB' }
+  bundlesize: { maxSize: '16kB' }
 }

--- a/.aegir.js
+++ b/.aegir.js
@@ -1,3 +1,3 @@
 module.exports = {
-  bundlesize: { maxSize: '12.1kB' }
+  bundlesize: { maxSize: '13.7kB' }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "buffer": "^5.5.0",
     "idb": "^5.0.2",
-    "interface-datastore": "^1.0.3"
+    "interface-datastore": "^1.0.3",
+    "p-queue": "^6.4.0"
   },
   "devDependencies": {
     "aegir": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "buffer": "^5.5.0",
     "idb": "^5.0.2",
-    "interface-datastore": "^1.0.2"
+    "interface-datastore": "^1.0.3"
   },
   "devDependencies": {
     "aegir": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "buffer": "^5.5.0",
     "idb": "^5.0.2",
-    "interface-datastore": "^1.0.3",
+    "interface-datastore": "ipfs/interface-datastore#test/add-tests-for-mutating-datastore-during-query",
     "p-queue": "^6.4.0"
   },
   "devDependencies": {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -5,6 +5,7 @@ const { MountDatastore } = require('datastore-core')
 const { Key } = require('interface-datastore')
 const { isNode } = require('ipfs-utils/src/env')
 const IDBStore = require('../src')
+const { expect } = require('aegir/utils/chai')
 
 describe('IndexedDB Datastore', function () {
   if (isNode) {
@@ -105,7 +106,7 @@ describe('IndexedDB Datastore', function () {
         } catch (err) {
           clearInterval(updater)
           clearInterval(mutatorQuery)
-          clearInterval(queryier)
+          clearInterval(readOnlyQuery)
           done(err)
         }
       }, 0)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -52,7 +52,7 @@ describe('IndexedDB Datastore', function () {
     })
   })
 
-  describe.only('concurrency', () => {
+  describe('concurrency', () => {
     let store
 
     before(async () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,7 +6,7 @@ const { Key } = require('interface-datastore')
 const { isNode } = require('ipfs-utils/src/env')
 const IDBStore = require('../src')
 
-describe('LevelDatastore', function () {
+describe('IndexedDB Datastore', function () {
   if (isNode) {
     return
   }


### PR DESCRIPTION
To get a cursor to operate over a set of keys from an idb store, you
have to start a transaction. That transaction will remain open as long
as there are tasks in the microtask queue - when it empties the
transaction is automatically closed.

Transactions operate on an ObjectStore, puts and gets not to the object
store also seem to close the transaction.

This change adds a `_getStore` method to the datastore which
creates a new transaction if there was no previous transaction, or if
the previous transaction was closed.  All operations then take place as
part of this transaction.